### PR TITLE
Fix temp dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,9 @@ ignore = [
 # bandit -c pyproject.toml -r .
 exclude_dirs = [".bak", "venv"]
 skips = [
-    "B108"  # hard coded /tmp/... files are fine for me tbh
+    "B101", # Use of assert detected.
+    "B105", # hardcoded_password_string
+    "B106", # hardcoded_password_funcarg
 ]
 
 [tool.isort]

--- a/src/lib2fas/_security.py
+++ b/src/lib2fas/_security.py
@@ -7,6 +7,7 @@ import getpass
 import hashlib
 import json
 import logging
+import tempfile
 import time
 import warnings
 from pathlib import Path
@@ -77,7 +78,7 @@ class KeyringManager:
     """
 
     appname: str = ""
-    tmp_file = Path("/tmp") / ".2fas"
+    tmp_file = Path(tempfile.gettempdir()) / ".2fas"
 
     def __init__(self) -> None:
         """

--- a/tests/test_encrypted.py
+++ b/tests/test_encrypted.py
@@ -21,13 +21,13 @@ def clean_keyring():
 
 
 @pytest.fixture
-def getpass_wrong(clean_keyring, monkeypatch):
+def getpass_wrong(_clean_keyring, monkeypatch):
     """Did the file we wrote actually become json."""
     monkeypatch.setattr("getpass.getpass", lambda _: "***")
 
 
 @pytest.fixture
-def getpass_correct(clean_keyring, monkeypatch):
+def getpass_correct(_clean_keyring, monkeypatch):
     """Did the file we wrote actually become json."""
     monkeypatch.setattr("getpass.getpass", lambda _: PASSWORD)
 
@@ -38,12 +38,12 @@ def getpass_empty(monkeypatch):
     monkeypatch.setattr("getpass.getpass", lambda _: "")
 
 
-def test_wrong_pass(getpass_wrong):
+def test_wrong_pass(_getpass_wrong):
     with pytest.raises(PermissionError):
         assert not load_services(FILENAME, _max_retries=1)
 
 
-def test_pass_noninteractive(getpass_wrong):
+def test_pass_noninteractive(_getpass_wrong):
     with pytest.raises(PermissionError):
         assert not load_services(FILENAME, _max_retries=1, passphrase="")
 
@@ -51,12 +51,12 @@ def test_pass_noninteractive(getpass_wrong):
     assert services
 
 
-def test_right_pass(getpass_correct):
+def test_right_pass(_getpass_correct):
     services = load_services(FILENAME)
     assert services
 
 
-def test_from_keyring(getpass_empty):
+def test_from_keyring(_getpass_empty):
     # note: `test_right_pass` MUST be executed right before!
     services = load_services(FILENAME, _max_retries=1)
     assert services


### PR DESCRIPTION
Your library was just what I needed for a simple [2fas tray icon app](https://github.com/crmarsh/2fas-desktop) I threw together, but had to hack around not having a `/tmp` path; figured I could send a quick patch.

I tried running the linters and such that were in that pyproject.toml file, and added a couple fixes to make those pass too. I'm not super familiar with doing Python things that are not one-off scripts, so apologies in advance if this is silly or wrong.